### PR TITLE
Fix/sftpc 50 (#126)

### DIFF
--- a/src/main/java/org/mule/extension/sftp/internal/SftpInputStream.java
+++ b/src/main/java/org/mule/extension/sftp/internal/SftpInputStream.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 
 import com.jcraft.jsch.SftpException;
 
+import static com.jcraft.jsch.ChannelSftp.SSH_FX_NO_SUCH_FILE;
+
 /**
  * Implementation of {@link AbstractNonFinalizableFileInputStream} for SFTP connections
  *
@@ -90,8 +92,6 @@ public class SftpInputStream extends AbstractNonFinalizableFileInputStream {
 
   protected static class SftpFileInputStreamSupplier extends AbstractConnectedFileInputStreamSupplier<SftpFileSystem> {
 
-    private static final String FILE_NOT_FOUND_EXCEPTION = "FileNotFoundException";
-
     private SftpFileInputStreamSupplier(SftpFileAttributes attributes, ConnectionManager connectionManager,
                                         Long timeBetweenSizeCheck, SftpConnector config) {
       super(attributes, connectionManager, timeBetweenSizeCheck, config);
@@ -113,7 +113,10 @@ public class SftpInputStream extends AbstractNonFinalizableFileInputStream {
 
     @Override
     protected boolean fileWasDeleted(MuleRuntimeException e) {
-      return e.getCause() instanceof SftpException && e.getCause().getMessage().contains(FILE_NOT_FOUND_EXCEPTION);
+      if (e.getCause() instanceof SftpException) {
+        return ((SftpException) e.getCause()).id == SSH_FX_NO_SUCH_FILE;
+      }
+      return false;
     }
   }
 }

--- a/src/test/munit/sftp-write-test-case.xml
+++ b/src/test/munit/sftp-write-test-case.xml
@@ -164,4 +164,37 @@
         </munit:validation>
     </munit:test>
 
+
+    <munit:test name="sftp-write-deleted-file" description="Use the list operation to get the file content and try to write it but it was deleted before and should expect exception"
+                expectedErrorType="SFTP:FILE_DOESNT_EXIST">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="delete-created-files"/>
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <set-variable variableName="fileName" value="/will-be-deleted.txt"/>
+            <sftp:write config-ref="${config}" path='#[vars.fileName]' >
+                <sftp:content>test content</sftp:content>
+            </sftp:write>
+        </munit:behavior>
+        <munit:execution>
+            <sftp:list config-ref="${config}" directoryPath="/">
+            </sftp:list>
+            <flow-ref name="wait-2-seconds"/>
+            <foreach collection="#[payload]">
+                <sftp:write config-ref="${config}" path="/copy-of-will-be-deleted.txt" createParentDirectories="false" >
+                </sftp:write>
+            </foreach>
+        </munit:execution>
+    </munit:test>
+
+
+
+    <flow name="delete-created-files">
+        <sftp:listener config-ref="${config}" directory="/">
+            <scheduling-strategy>
+                <fixed-frequency startDelay="2000"/>
+            </scheduling-strategy>
+        </sftp:listener>
+        <sftp:delete config-ref="${config}" path="#[attributes.path]" />
+    </flow>
 </mule>


### PR DESCRIPTION
* Rewritten SftpInputStream#fileWasDeleted so it properly detect deleted files
Improved exception handling

* replaced hardcoded value with existing constant

* Exception message might be different
Exception id is enough

* Added test for writing a file based on a deleted file's content stream.

Co-authored-by: Dan Cazacu <dcazacu@salesforce.com>
(cherry picked from commit 248eff708afc04e67bddc90a4c76b3cf7ccb4cae)