### PR TITLE
Improved exception handling for SFTP:ACCESS_DENIED error code (#149)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
                                     <alias>toxiproxy</alias>
                                     <run>
                                         <ports>
-                                            <port>8474:8474</port>
+                                            <port>${toxiproxy.port}:8474</port>
                                             <port>${connection.lost.port}:${connection.lost.port}</port>
                                         </ports>
                                         <links>

--- a/src/main/java/org/mule/extension/sftp/internal/AbstractSftpCopyDelegate.java
+++ b/src/main/java/org/mule/extension/sftp/internal/AbstractSftpCopyDelegate.java
@@ -113,6 +113,8 @@ public abstract class AbstractSftpCopyDelegate implements SftpCopyDelegate {
       }
 
       writeCopy(config, target.getPath(), inputStream, overwrite, writerConnection);
+    } catch (ModuleException e) {
+      throw e;
     } catch (Exception e) {
       throw command
           .exception(format("Found exception while trying to copy file '%s' to remote path '%s'", source.getPath(), target), e);

--- a/src/main/java/org/mule/extension/sftp/internal/SftpFileCopyErrorTypeProvider.java
+++ b/src/main/java/org/mule/extension/sftp/internal/SftpFileCopyErrorTypeProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.extension.sftp.internal;
+
+import org.mule.extension.file.common.api.exceptions.FileCopyErrorTypeProvider;
+import org.mule.runtime.extension.api.error.ErrorTypeDefinition;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
+import static org.mule.extension.file.common.api.exceptions.FileError.FILE_ALREADY_EXISTS;
+import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
+import static org.mule.extension.file.common.api.exceptions.FileError.ACCESS_DENIED;
+
+public class SftpFileCopyErrorTypeProvider extends FileCopyErrorTypeProvider {
+
+  @Override
+  public Set<ErrorTypeDefinition> getErrorTypes() {
+    return unmodifiableSet(new HashSet<>(asList(ILLEGAL_PATH, FILE_ALREADY_EXISTS, ACCESS_DENIED)));
+  }
+}

--- a/src/main/java/org/mule/extension/sftp/internal/SftpOperations.java
+++ b/src/main/java/org/mule/extension/sftp/internal/SftpOperations.java
@@ -17,7 +17,6 @@ import org.mule.extension.file.common.api.FileAttributes;
 import org.mule.extension.file.common.api.FileConnectorConfig;
 import org.mule.extension.file.common.api.FileSystem;
 import org.mule.extension.file.common.api.FileWriteMode;
-import org.mule.extension.file.common.api.exceptions.FileCopyErrorTypeProvider;
 import org.mule.extension.file.common.api.exceptions.FileDeleteErrorTypeProvider;
 import org.mule.extension.file.common.api.exceptions.FileListErrorTypeProvider;
 import org.mule.extension.file.common.api.exceptions.FileReadErrorTypeProvider;
@@ -204,7 +203,7 @@ public final class SftpOperations extends BaseFileSystemOperations {
    * @throws IllegalArgumentException if an illegal combination of arguments is supplied
    */
   @Summary("Copies a file")
-  @Throws(FileCopyErrorTypeProvider.class)
+  @Throws(SftpFileCopyErrorTypeProvider.class)
   public void copy(@Config FileConnectorConfig config, @Connection FileSystem fileSystem,
                    @Path(location = EXTERNAL) String sourcePath,
                    @Path(type = DIRECTORY, location = EXTERNAL) String targetPath,
@@ -236,7 +235,7 @@ public final class SftpOperations extends BaseFileSystemOperations {
    * @throws IllegalArgumentException if an illegal combination of arguments is supplied
    */
   @Summary("Moves a file")
-  @Throws(FileCopyErrorTypeProvider.class)
+  @Throws(SftpFileCopyErrorTypeProvider.class)
   public void move(@Config FileConnectorConfig config, @Connection FileSystem fileSystem,
                    @Path(location = EXTERNAL) String sourcePath,
                    @Path(type = DIRECTORY, location = EXTERNAL) String targetPath,

--- a/src/main/java/org/mule/extension/sftp/internal/command/SftpCommand.java
+++ b/src/main/java/org/mule/extension/sftp/internal/command/SftpCommand.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.util.Stack;
 
 import org.apache.commons.io.FilenameUtils;
+import org.mule.runtime.extension.api.exception.ModuleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +86,8 @@ public abstract class SftpCommand extends ExternalFileCommand<SftpFileSystem> {
     SftpFileAttributes attributes;
     try {
       attributes = client.getAttributes(uri);
+    } catch (ModuleException e) {
+      throw e;
     } catch (Exception e) {
       throw exception("Found exception trying to obtain path " + uri.getPath(), e);
     }

--- a/src/main/java/org/mule/extension/sftp/internal/connection/SftpClient.java
+++ b/src/main/java/org/mule/extension/sftp/internal/connection/SftpClient.java
@@ -6,6 +6,7 @@
  */
 package org.mule.extension.sftp.internal.connection;
 
+import static com.jcraft.jsch.ChannelSftp.SSH_FX_PERMISSION_DENIED;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.mule.extension.file.common.api.util.UriUtils.createUri;
@@ -46,6 +47,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.function.Supplier;
 
+import org.mule.runtime.extension.api.exception.ModuleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -405,6 +407,9 @@ public class SftpClient {
     if (cause instanceof SftpException) {
       if (cause.getCause() instanceof IOException) {
         return exception(message, new ConnectionException(cause, owner));
+      }
+      if (((SftpException) cause).id == SSH_FX_PERMISSION_DENIED) {
+        return new ModuleException(message, FileError.ACCESS_DENIED, cause);
       }
     }
     return new MuleRuntimeException(createStaticMessage(message), cause);

--- a/src/test/munit/configurations.xml
+++ b/src/test/munit/configurations.xml
@@ -25,6 +25,15 @@
         </sftp:connection>
     </sftp:config>
 
+    <sftp:config name="config-docker-server">
+        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
+                         workingDir="/" prngAlgorithm="SHA1PRNG">
+            <reconnection>
+                <reconnect count="20" frequency="1000"/>
+            </reconnection>
+        </sftp:connection>
+    </sftp:config>
+
     <sftp:config name="config-with-reconnection">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
                          workingDir="/" prngAlgorithm="SHA1PRNG">

--- a/src/test/munit/sftp-copy-test-case.xml
+++ b/src/test/munit/sftp-copy-test-case.xml
@@ -115,4 +115,22 @@
         </munit:validation>
     </munit:test>
 
+    <munit:test
+            name="sftp-copy-access-denied-on-read"
+            description="This test is trying to copy a read protected file. The expected error code should be SFTP:ACCESS_DENIED"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:copy config-ref="config-docker-server" sourcePath="/etc/sudoers" targetPath="/usr/"/>
+        </munit:execution>
+    </munit:test>
+
+    <munit:test
+            name="sftp-copy-access-denied-on-write"
+            description="This test is trying to copy a file to a write protected folder. The expected error code should be SFTP:ACCESS_DENIED"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:copy config-ref="config-docker-server" sourcePath="/init" targetPath="/root/init-copy"/>
+        </munit:execution>
+    </munit:test>
+
 </mule>

--- a/src/test/munit/sftp-create-directory-test-case.xml
+++ b/src/test/munit/sftp-create-directory-test-case.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+
+    <munit:config name="sftp-create-directory-test-case.xml"/>
+
+    <munit:dynamic-port propertyName="sftp.server.port"/>
+
+    <munit:test
+            name="sftp-create-directory-access-denied"
+            description="Trying to create a directory in a write protected folder. SFTP:ACCESS_DENIED error code is expected"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:create-directory config-ref="config-docker-server" directoryPath="/root/newDir"/>
+        </munit:execution>
+    </munit:test>
+
+</mule>

--- a/src/test/munit/sftp-delete-test-case.xml
+++ b/src/test/munit/sftp-delete-test-case.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+
+    <munit:config name="sftp-delete-test-case.xml"/>
+
+    <munit:dynamic-port propertyName="sftp.server.port"/>
+
+    <munit:test
+            name="sftp-delete-directory-access-denied"
+            description="Trying to delete a write protected directory. SFTP:ACCESS_DENIED error code is expected"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:delete config-ref="config-docker-server" path="/root"/>
+        </munit:execution>
+    </munit:test>
+
+    <munit:test
+            name="sftp-delete-file-access-denied"
+            description="Trying to delete a write protected file. SFTP:ACCESS_DENIED error code is expected"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:delete config-ref="config-docker-server" path="/etc/sudoers"/>
+        </munit:execution>
+    </munit:test>
+
+</mule>

--- a/src/test/munit/sftp-directory-listener-on-connection-exception.xml
+++ b/src/test/munit/sftp-directory-listener-on-connection-exception.xml
@@ -17,6 +17,7 @@
     <munit:dynamic-port propertyName="sftp.server.port"/>
 
     <munit:before-suite name="startDirectoryListenerReconnectionTestProxy">
+        <connection-test:define-proxy-server-port serverPort="${toxiproxy.port}"/>
         <connection-test:create-proxy realPort="2222" realHost="openssh" proxyPort="${connection.lost.port}"/>
     </munit:before-suite>
 

--- a/src/test/munit/sftp-list-test-case.xml
+++ b/src/test/munit/sftp-list-test-case.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+
+    <munit:config name="sftp-list-test-case.xml"/>
+
+    <munit:dynamic-port propertyName="sftp.server.port"/>
+
+    <munit:test
+            name="sftp-list-access-denied"
+            description="Trying to list '\root' directory without root access. SFTP:ACCESS_DENIED error code is expected"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:list config-ref="config-docker-server" directoryPath="/root"/>
+        </munit:execution>
+    </munit:test>
+
+</mule>

--- a/src/test/munit/sftp-move-test-case.xml
+++ b/src/test/munit/sftp-move-test-case.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+
+    <munit:config name="sftp-move-test-case.xml"/>
+
+    <munit:dynamic-port propertyName="sftp.server.port"/>
+
+    <munit:test
+            name="sftp-move-access-denied"
+            description="Trying to move a file to a write protected folder. SFTP:ACCESS_DENIED error code is expected"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:move config-ref="config-docker-server" sourcePath="/init" targetPath="/root/init-move"/>
+        </munit:execution>
+    </munit:test>
+
+</mule>

--- a/src/test/munit/sftp-read-test-case.xml
+++ b/src/test/munit/sftp-read-test-case.xml
@@ -65,4 +65,13 @@
             </munit-tools:assert>
         </munit:validation>
     </munit:test>
+
+    <munit:test name="sftp-read-file-permission-denied"
+                description="Trying to read for a protected file should throw SFTP:ACCESS_DENIED. The exception is thrown when the stream is evaluated (write operation)."
+                expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:read config-ref="config-docker-server" path="/etc/sudoers"/>
+            <sftp:write config-ref="config-docker-server" path="/tmp/sudoers-copy"/>
+        </munit:execution>
+    </munit:test>
 </mule>

--- a/src/test/munit/sftp-rename-test-case.xml
+++ b/src/test/munit/sftp-rename-test-case.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+
+    <munit:config name="sftp-rename-directory-test-case.xml"/>
+
+    <munit:dynamic-port propertyName="sftp.server.port"/>
+
+    <munit:test
+            name="sftp-rename-access-denied"
+            description="Trying to rename a file inside a read protected folder. SFTP:ACCESS_DENIED error code is expected"
+            expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:rename config-ref="config-docker-server" path="/root/cannotReadFromRoot" to="cannotReadFromRoot2"/>
+        </munit:execution>
+    </munit:test>
+
+</mule>

--- a/src/test/munit/sftp-write-test-case.xml
+++ b/src/test/munit/sftp-write-test-case.xml
@@ -163,7 +163,25 @@
             </munit-tools:assert>
         </munit:validation>
     </munit:test>
+  
+    <munit:test name="sftp-write-file-permission-denied-directory"
+                description="Trying write a file to a write protected folder should throw SFTP:ACCESS_DENIED."
+                expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:read config-ref="config-docker-server" path="/init"/>
+            <sftp:write config-ref="config-docker-server" path="/root/init"/>
+        </munit:execution>
+    </munit:test>
 
+    <munit:test name="sftp-write-file-permission-denied"
+                description="Trying write content to a write protected file should throw SFTP:ACCESS_DENIED."
+                expectedErrorType="SFTP:ACCESS_DENIED">
+        <munit:execution>
+            <sftp:write config-ref="config-docker-server" path="/init">
+                <sftp:content>Some content</sftp:content>
+            </sftp:write>
+        </munit:execution>
+    </munit:test>
 
     <munit:test name="sftp-write-deleted-file" description="Use the list operation to get the file content and try to write it but it was deleted before and should expect exception"
                 expectedErrorType="SFTP:FILE_DOESNT_EXIST">
@@ -197,4 +215,5 @@
         </sftp:listener>
         <sftp:delete config-ref="${config}" path="#[attributes.path]" />
     </flow>
+
 </mule>


### PR DESCRIPTION
* Improved exception handling for SFTP:ACCESS_DENIED error code.
Added tests that cover most of the usescase for this error code.
Changed ErrorTypeProvider for Copy and Move operations. Added SFTP:ACCESS_DENIED.

* Properly configured dynamic port for toxi-proxy