### PR TITLE
Truncate is required by V4 SFTP Server to overwrite files

### DIFF
--- a/src/main/java/org/mule/extension/sftp/internal/connection/SftpClient.java
+++ b/src/main/java/org/mule/extension/sftp/internal/connection/SftpClient.java
@@ -78,7 +78,7 @@ import org.slf4j.Logger;
 public class SftpClient {
 
   private static final Logger LOGGER = getLogger(SftpClient.class);
-  protected static final OpenMode[] CREATE_MODES = {OpenMode.Write, OpenMode.Create};
+  protected static final OpenMode[] CREATE_MODES = {OpenMode.Write, OpenMode.Create, OpenMode.Truncate};
   protected static final OpenMode[] APPEND_MODES = {OpenMode.Write, OpenMode.Append};
   public static final Long PWD_COMMAND_EXECUTION_TIMEOUT = 30L;
   private static final TimeUnit PWD_COMMAND_EXECUTION_TIMEOUT_UNIT = SECONDS;


### PR DESCRIPTION
We switched <artifactId>mule-sftp-connector</artifactId>
from 1.6.1 to 2.0.1 but now our V4 compatible MFT Server ( https://www.goanywhere.com/products/goanywhere-mft )
does no longer overwrite files but appending.

In the debug log you can see our SFTP is version 4
[mft-demo.canda.com/10.16.146.13:22](http://mft-demo.canda.com/10.16.146.13:22)][sftp]) current=4
and file is written with
[/deve/test_sftp/MASTERDATA.CSV] options=[Write, Create]

But on previous 1.6.1 version the jsch did sent
sendOPEN(path, SSH_FXF_WRITE|SSH_FXF_CREAT|**SSH_FXF_TRUNC**);
which informed SFTP Server to truncate the file before write. ( com.jcraft.jsch.ChannelSftp.sendOPENW(byte[]) )

That truncate now is missing.

OpenMode.**Truncate** needs to be added to
org.mule.extension.sftp.internal.connection.SftpClient.**CREATE_MODES**
(for org.mule.extension.sftp.internal.connection.SftpClient.toApacheSshdModes(FileWriteMode))

(For sending mode to SFTP Server, see org.apache.sshd.sftp.client.impl.AbstractSftpClient.open(String, Collection<OpenMode>)))