### PR TITLE
W-17156076 Using NativePRNG in place of SHA1PRNG

### DIFF
--- a/src/main/java/org/mule/extension/sftp/api/random/alg/PRNGAlgorithm.java
+++ b/src/main/java/org/mule/extension/sftp/api/random/alg/PRNGAlgorithm.java
@@ -17,7 +17,7 @@ import org.apache.sshd.common.util.security.SecurityUtils;
 
 public enum PRNGAlgorithm {
 
-  AUTOSELECT("AUTOSELECT", new SingletonRandomFactory(SecurityUtils.getRandomFactory())), SHA1PRNG("SHA1PRNG",
+  AUTOSELECT("AUTOSELECT", new SingletonRandomFactory(SecurityUtils.getRandomFactory())), SHA1PRNG_DEPRECATED("SHA1PRNG",
       SHA1PRGRandomFactory.INSTANCE), NativePRNG("NativePRNG", NativePRNGRandomFactory.INSTANCE), NativePRNGBlocking(
           "NativePRNGBlocking", NativeBlockingPRNGRandomFactory.INSTANCE), NativePRNGNonBlocking("NativePRNGNonBlocking",
               NativeNonBlockingPRNGFactory.INSTANCE);

--- a/src/test/it/tita/src/test/resources/sftp-reconnection-app.xml
+++ b/src/test/it/tita/src/test/resources/sftp-reconnection-app.xml
@@ -28,7 +28,7 @@
 
     <sftp:config name="sftp-config">
         <sftp:connection username="mule" password="test" host="127.0.0.1" port="${sftp.listener.port}"
-                         workingDir="/app" prngAlgorithm="SHA1PRNG">
+                         workingDir="/app" prngAlgorithm="NativePRNG">
             <reconnection >
                 <reconnect-forever />
             </reconnection>

--- a/src/test/it/tita/src/test/resources/sftp-reconnection-with-id-file-app.xml
+++ b/src/test/it/tita/src/test/resources/sftp-reconnection-with-id-file-app.xml
@@ -28,7 +28,7 @@
 
     <sftp:config name="sftp-config">
         <sftp:connection username="mule" password="test" host="127.0.0.1" port="${sftp.listener.port}"
-                         workingDir="/app" prngAlgorithm="SHA1PRNG" identityFile="id_ed25519" passphrase="mulesoft">
+                         workingDir="/app" prngAlgorithm="NativePRNG" identityFile="id_ed25519" passphrase="mulesoft">
             <reconnection >
                 <reconnect-forever />
             </reconnection>

--- a/src/test/java/org/mule/extension/sftp/SftpClientTestCase.java
+++ b/src/test/java/org/mule/extension/sftp/SftpClientTestCase.java
@@ -64,7 +64,7 @@ public class SftpClientTestCase {
   protected SchedulerService schedulerService;
 
   @InjectMocks
-  private SftpClient client = new SftpClient(EMPTY, 0, PRNGAlgorithm.SHA1PRNG, schedulerService, true, null, Properties::new);
+  private SftpClient client = new SftpClient(EMPTY, 0, PRNGAlgorithm.NativePRNG, schedulerService, true, null, Properties::new);
 
   @Test
   public void returnNullOnUnexistingFile() throws Exception {

--- a/src/test/java/org/mule/extension/sftp/SftpTestHarness.java
+++ b/src/test/java/org/mule/extension/sftp/SftpTestHarness.java
@@ -124,7 +124,8 @@ public class SftpTestHarness extends AbstractSftpTestHarness {
 
   private SftpClient createDefaultSftpClient() throws IOException, GeneralSecurityException {
     SftpClient sftpClient =
-        new SftpClientFactory().createInstance("localhost", sftpPort.getNumber(), PRNGAlgorithm.SHA1PRNG, schedulerService, null,
+        new SftpClientFactory().createInstance("localhost", sftpPort.getNumber(), PRNGAlgorithm.NativePRNG, schedulerService,
+                                               null,
                                                true, Properties::new);
     clientAuthConfigurator.configure(sftpClient);
 

--- a/src/test/munit/configurations.xml
+++ b/src/test/munit/configurations.xml
@@ -15,33 +15,33 @@
 
     <sftp:config name="config">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="15" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="file-enabled-config">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG" sshConfigOverride="${app.home}/mule_sshd_config">
+                         workingDir="/" prngAlgorithm="NativePRNG" sshConfigOverride="${app.home}/mule_sshd_config">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="unknown-file-enabled-config">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG" sshConfigOverride="${app.home}/mule_sshd">
+                         workingDir="/" prngAlgorithm="NativePRNG" sshConfigOverride="${app.home}/mule_sshd">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="strict-KEX-enabled-config">
-        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}" prngAlgorithm="SHA1PRNG" kexHeader="true">
+        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}" prngAlgorithm="NativePRNG" kexHeader="true">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="strict-KEX-disabled-config">
-        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}" prngAlgorithm="SHA1PRNG" kexHeader="false">
+        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}" prngAlgorithm="NativePRNG" kexHeader="false">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
@@ -52,7 +52,7 @@
                          host="openssh${sftp.proxy.auth}"
                          port="2222"
                          workingDir="/config"
-                         prngAlgorithm="SHA1PRNG"
+                         prngAlgorithm="NativePRNG"
                          connectionTimeout="200">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
             <sftp:sftp-proxy-config host="localhost"
@@ -65,28 +65,28 @@
 
     <sftp:config name="config-invalid-password">
         <sftp:connection username="muletest1" password="INVALID" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="config-no-username">
         <sftp:connection password="INVALID" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="config-with-identity-file-not-exists">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}" identityFile="a-file-that-doesnt-exist"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="config-with-reconnection">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <reconnection >
                 <reconnect count="20" frequency="1000"/>
             </reconnection>
@@ -96,7 +96,7 @@
 
     <sftp:config name="config-without-working-dir">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         prngAlgorithm="SHA1PRNG">
+                         prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
@@ -108,26 +108,26 @@
 
     <sftp:config name="config-docker">
         <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
-                         workingDir="/config" prngAlgorithm="SHA1PRNG">
+                         workingDir="/config" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="config-docker-with-home-directory">
         <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
-                         workingDir="/config" prngAlgorithm="SHA1PRNG">
+                         workingDir="/config" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="config-docker-with-private-directory">
         <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
     <sftp:config name="config-docker-without-home-directory">
-        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}" prngAlgorithm="SHA1PRNG">
+        <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}" prngAlgorithm="NativePRNG">
             <reconnection>
                 <reconnect count="20" frequency="1000"/>
             </reconnection>
@@ -151,14 +151,14 @@
 
     <sftp:config name="config-invalid-folder">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         workingDir="/invalid" prngAlgorithm="SHA1PRNG">
+                         workingDir="/invalid" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>
 
     <sftp:config name="config-docker-with-id-file">
         <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
-                         workingDir="/config" prngAlgorithm="SHA1PRNG"
+                         workingDir="/config" prngAlgorithm="NativePRNG"
                          identityFile="id_ed25519" passphrase="mulesoft">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>

--- a/src/test/munit/proxy/sftp-proxy-socks-test-case.xml
+++ b/src/test/munit/proxy/sftp-proxy-socks-test-case.xml
@@ -39,7 +39,7 @@
                          host="${sftp.host}"
                          port="${sftp.port}"
                          workingDir="/"
-                         prngAlgorithm="SHA1PRNG"
+                         prngAlgorithm="NativePRNG"
                          connectionTimeout="200">
             <sftp:sftp-proxy-config host="localhost"
                                     port="${proxy.port}"
@@ -55,7 +55,7 @@
                          host="local-error"
                          port="${sftp.port}"
                          workingDir="/"
-                         prngAlgorithm="SHA1PRNG"
+                         prngAlgorithm="NativePRNG"
                          connectionTimeout="200">
             <sftp:sftp-proxy-config host="localhost"
                                     port="${proxy.port}"

--- a/src/test/munit/sftp-id-file-connection-test-case.xml
+++ b/src/test/munit/sftp-id-file-connection-test-case.xml
@@ -26,7 +26,7 @@
 
     <sftp:config name="config-docker-with-id-file-1">
         <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
-                         workingDir="/config" prngAlgorithm="SHA1PRNG"
+                         workingDir="/config" prngAlgorithm="NativePRNG"
                          identityFile="id_ed25519" passphrase="mulesoft">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>
@@ -34,7 +34,7 @@
 
     <sftp:config name="config-docker-with-id-file-2">
         <sftp:connection username="mule" password="test" host="localhost" port="${sftp.listener.port}"
-                         workingDir="/config" prngAlgorithm="SHA1PRNG"
+                         workingDir="/config" prngAlgorithm="NativePRNG"
                          identityFile="id_ed25519" passphrase="mulesoft">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="7" maxIdle="3" maxWait="5000"/>
         </sftp:connection>

--- a/src/test/munit/sftp-proxy-test-case.xml
+++ b/src/test/munit/sftp-proxy-test-case.xml
@@ -30,7 +30,7 @@
                          host="openssh${sftp.proxy.auth}"
                          port="2222"
                          workingDir="/config"
-                         prngAlgorithm="SHA1PRNG"
+                         prngAlgorithm="NativePRNG"
                          connectionTimeout="200">
             <sftp:sftp-proxy-config host="localhost"
                                     port="${squid.port.auth}"
@@ -46,7 +46,7 @@
                          host="local-error"
                          port="${sftp.proxy.auth}"
                          workingDir="/config"
-                         prngAlgorithm="SHA1PRNG"
+                         prngAlgorithm="NativePRNG"
                          connectionTimeout="200">
             <sftp:sftp-proxy-config host="localhost"
                                     port="${squid.port.auth}"

--- a/src/test/munit/sftp-read-test-case.xml
+++ b/src/test/munit/sftp-read-test-case.xml
@@ -29,7 +29,7 @@
 
     <sftp:config name="config-with-limited-pool">
         <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${sftp.server.port}"
-                         workingDir="/" prngAlgorithm="SHA1PRNG">
+                         workingDir="/" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="1" maxIdle="1" maxWait="5000"/>
         </sftp:connection>
     </sftp:config>

--- a/src/test/resources/sftp-connection-config.xml
+++ b/src/test/resources/sftp-connection-config.xml
@@ -6,7 +6,7 @@
         http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
 
     <sftp:config name="config">
-        <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG" >
+        <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="NativePRNG" >
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="3" maxIdle="3" maxWait="1000"/>
         </sftp:connection>
     </sftp:config>

--- a/src/test/resources/sftp-connection-with-identity-file.xml
+++ b/src/test/resources/sftp-connection-with-identity-file.xml
@@ -6,7 +6,7 @@
         http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
 
     <sftp:config name="config">
-        <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" identityFile="sftp-test-key" prngAlgorithm="SHA1PRNG">
+        <sftp:connection username="muletest1" password="muletest1" host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" identityFile="sftp-test-key" prngAlgorithm="NativePRNG">
             <pooling-profile exhaustedAction="WHEN_EXHAUSTED_WAIT" maxActive="3" maxIdle="3" maxWait="1000"/>
         </sftp:connection>
     </sftp:config>

--- a/src/test/resources/sftp-negative-connectivity-test.xml
+++ b/src/test/resources/sftp-negative-connectivity-test.xml
@@ -6,31 +6,31 @@
         http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
 
     <sftp:config name="sftpConfigInvalidCredentials">
-        <sftp:connection username="invalidUser" password="invalidPassword" host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection username="invalidUser" password="invalidPassword" host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
     <sftp:config name="sftpConfigConnectionTimeout">
-        <sftp:connection username="muletest1" password="muletest1" host="google.com" port="${SFTP_PORT}" workingDir="${workingDir}" connectionTimeout="1" connectionTimeoutUnit="MILLISECONDS" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection username="muletest1" password="muletest1" host="google.com" port="${SFTP_PORT}" workingDir="${workingDir}" connectionTimeout="1" connectionTimeoutUnit="MILLISECONDS" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
     <sftp:config name="sftpConfigConnectionRefused">
-        <sftp:connection username="muletest1" password="muletest1" host="localhost" port="8888" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection username="muletest1" password="muletest1" host="localhost" port="8888" workingDir="${workingDir}" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
     <sftp:config name="sftpConfigMissingCredentials">
-        <sftp:connection host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
     <sftp:config name="sftpConfigUnknownHost">
-        <sftp:connection username="anonymous" password="password"  host="dsadsadas" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection username="anonymous" password="password"  host="dsadsadas" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
     <sftp:config name="sftpConfigFirstConnection">
-        <sftp:connection username="limitedUsed" password="limitedUsed"  host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection username="limitedUsed" password="limitedUsed"  host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
     <sftp:config name="sftpConfigServiceUnavailable">
-        <sftp:connection username="limitedUsed" password="limitedUsed"  host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="SHA1PRNG"/>
+        <sftp:connection username="limitedUsed" password="limitedUsed"  host="localhost" port="${SFTP_PORT}" workingDir="${workingDir}" prngAlgorithm="NativePRNG"/>
     </sftp:config>
 
 </mule>


### PR DESCRIPTION
**Issue** 
As mentioned in https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000252OC9YAM/view, we need to remove the SHA1PRNG algorithm as this is not safe to use.

**Fix**
Made changes to mark the SHA1PRNG as deprecated. We will remove this as part of a major release.

**Changes Done**
1. Updated the SHA1PRNG option to SHA1PRNG_Deprecated
2. Updated all test cases to use NativePRNG